### PR TITLE
Changes for BatchEE 1.0.4

### DIFF
--- a/extensions/beanio/pom.xml
+++ b/extensions/beanio/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>batchee-extensions</artifactId>
         <groupId>org.apache.batchee</groupId>
-        <version>1.0.3</version>
+        <version>1.0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>batchee-beanio</artifactId>

--- a/extensions/camel/pom.xml
+++ b/extensions/camel/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>batchee-extensions</artifactId>
         <groupId>org.apache.batchee</groupId>
-        <version>1.0.3</version>
+        <version>1.0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>batchee-camel</artifactId>

--- a/extensions/cdi/pom.xml
+++ b/extensions/cdi/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>batchee-extensions</artifactId>
         <groupId>org.apache.batchee</groupId>
-        <version>1.0.3</version>
+        <version>1.0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>batchee-cdi</artifactId>

--- a/extensions/commons-csv/pom.xml
+++ b/extensions/commons-csv/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>batchee-extensions</artifactId>
     <groupId>org.apache.batchee</groupId>
-    <version>1.0.3</version>
+    <version>1.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>batchee-commons-csv</artifactId>

--- a/extensions/extension-doc-helper/pom.xml
+++ b/extensions/extension-doc-helper/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <artifactId>batchee-extensions</artifactId>
     <groupId>org.apache.batchee</groupId>
-    <version>1.0.3</version>
+    <version>1.0.4-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/extensions/extras/pom.xml
+++ b/extensions/extras/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>batchee-extensions</artifactId>
         <groupId>org.apache.batchee</groupId>
-        <version>1.0.3</version>
+        <version>1.0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>batchee-extras</artifactId>

--- a/extensions/groovy/pom.xml
+++ b/extensions/groovy/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>batchee-extensions</artifactId>
         <groupId>org.apache.batchee</groupId>
-        <version>1.0.3</version>
+        <version>1.0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>batchee-groovy</artifactId>

--- a/extensions/hazelcast/pom.xml
+++ b/extensions/hazelcast/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>batchee-extensions</artifactId>
         <groupId>org.apache.batchee</groupId>
-        <version>1.0.3</version>
+        <version>1.0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>batchee-hazelcast</artifactId>

--- a/extensions/jackson/pom.xml
+++ b/extensions/jackson/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>batchee-extensions</artifactId>
         <groupId>org.apache.batchee</groupId>
-        <version>1.0.3</version>
+        <version>1.0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>batchee-jackson</artifactId>

--- a/extensions/jsefa/pom.xml
+++ b/extensions/jsefa/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>batchee-extensions</artifactId>
         <groupId>org.apache.batchee</groupId>
-        <version>1.0.3</version>
+        <version>1.0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>batchee-jsefa</artifactId>

--- a/extensions/jsonp/pom.xml
+++ b/extensions/jsonp/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>batchee-extensions</artifactId>
     <groupId>org.apache.batchee</groupId>
-    <version>1.0.3</version>
+    <version>1.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>batchee-jsonp</artifactId>

--- a/extensions/modelmapper/pom.xml
+++ b/extensions/modelmapper/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>batchee-extensions</artifactId>
     <groupId>org.apache.batchee</groupId>
-    <version>1.0.3</version>
+    <version>1.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>batchee-modelmapper</artifactId>

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>batchee</artifactId>
         <groupId>org.apache.batchee</groupId>
-        <version>1.0.3</version>
+        <version>1.0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>batchee-extensions</artifactId>

--- a/gui/jaxrs/jaxrs-client/pom.xml
+++ b/gui/jaxrs/jaxrs-client/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>batchee-jaxrs</artifactId>
         <groupId>org.apache.batchee</groupId>
-        <version>1.0.3</version>
+        <version>1.0.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/gui/jaxrs/jaxrs-common/pom.xml
+++ b/gui/jaxrs/jaxrs-common/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>batchee-jaxrs</artifactId>
         <groupId>org.apache.batchee</groupId>
-        <version>1.0.3</version>
+        <version>1.0.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/gui/jaxrs/jaxrs-server/pom.xml
+++ b/gui/jaxrs/jaxrs-server/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>batchee-jaxrs</artifactId>
         <groupId>org.apache.batchee</groupId>
-        <version>1.0.3</version>
+        <version>1.0.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/gui/jaxrs/pom.xml
+++ b/gui/jaxrs/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>batchee-gui</artifactId>
         <groupId>org.apache.batchee</groupId>
-        <version>1.0.3</version>
+        <version>1.0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>batchee-jaxrs</artifactId>

--- a/gui/jaxrs/webapp/pom.xml
+++ b/gui/jaxrs/webapp/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.apache.batchee</groupId>
         <artifactId>batchee-jaxrs</artifactId>
-        <version>1.0.3</version>
+        <version>1.0.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/gui/pom.xml
+++ b/gui/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>batchee</artifactId>
         <groupId>org.apache.batchee</groupId>
-        <version>1.0.3</version>
+        <version>1.0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>batchee-gui</artifactId>

--- a/gui/servlet/embedded/pom.xml
+++ b/gui/servlet/embedded/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <artifactId>batchee-servlet</artifactId>
     <groupId>org.apache.batchee</groupId>
-    <version>1.0.3</version>
+    <version>1.0.4-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/gui/servlet/pom.xml
+++ b/gui/servlet/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>batchee-gui</artifactId>
     <groupId>org.apache.batchee</groupId>
-    <version>1.0.3</version>
+    <version>1.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>batchee-servlet</artifactId>

--- a/gui/servlet/webapp/pom.xml
+++ b/gui/servlet/webapp/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <artifactId>batchee-servlet</artifactId>
     <groupId>org.apache.batchee</groupId>
-    <version>1.0.3</version>
+    <version>1.0.4-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.batchee</groupId>
         <artifactId>batchee</artifactId>
-        <version>1.0.3</version>
+        <version>1.0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>integration-tests</artifactId>

--- a/integration-tests/transaction/pom.xml
+++ b/integration-tests/transaction/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.batchee</groupId>
         <artifactId>integration-tests</artifactId>
-        <version>1.0.3</version>
+        <version>1.0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>integration-transaction</artifactId>

--- a/jbatch/pom.xml
+++ b/jbatch/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>batchee</artifactId>
     <groupId>org.apache.batchee</groupId>
-    <version>1.0.3</version>
+    <version>1.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>batchee-jbatch</artifactId>

--- a/jbatch/src/main/java/org/apache/batchee/container/cdi/BatchCDIInjectionExtension.java
+++ b/jbatch/src/main/java/org/apache/batchee/container/cdi/BatchCDIInjectionExtension.java
@@ -67,7 +67,11 @@ public class BatchCDIInjectionExtension implements Extension {
     }
 
     void beforeBeanDiscovery(final @Observes BeforeBeanDiscovery bbd, BeanManager bm) {
-        bbd.addAnnotatedType(bm.createAnnotatedType(BatchProducerBean.class));
+        try {
+            bbd.addAnnotatedType(bm.createAnnotatedType(BatchProducerBean.class), "batchee#BatchProducerBean");
+        } catch (final Throwable ignored) {
+            bbd.addAnnotatedType(bm.createAnnotatedType(BatchProducerBean.class));
+        }
     }
 
     public void setBeanManager(final @Observes AfterBeanDiscovery afterBeanDiscovery, final BeanManager beanManager) {

--- a/pom.xml
+++ b/pom.xml
@@ -21,12 +21,12 @@
     <parent>
         <groupId>org.apache</groupId>
         <artifactId>apache</artifactId>
-        <version>24</version>
+        <version>31</version>
     </parent>
 
     <groupId>org.apache.batchee</groupId>
     <artifactId>batchee</artifactId>
-    <version>1.0.3</version>
+    <version>1.0.4-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>BatchEE</name>
 
@@ -34,7 +34,7 @@
         <connection>scm:git:https://gitbox.apache.org/repos/asf/geronimo-batchee.git</connection>
         <developerConnection>scm:git:https://gitbox.apache.org/repos/asf/geronimo-batchee.git</developerConnection>
         <url>https://gitbox.apache.org/repos/asf/geronimo-batchee.git</url>
-      <tag>batchee-1.0.3</tag>
+      <tag>batchee-1.0.4-SNAPSHOT</tag>
     </scm>
 
 
@@ -45,12 +45,12 @@
         <jaxb.version>2.3.4</jaxb.version>
         <atinject.version>1.0</atinject.version>
         <batch-api.version>1.0</batch-api.version>
-        <jackson.version>2.2.2</jackson.version>
+        <jackson.version>2.17.0</jackson.version>
         <jodatime.version>2.10.9</jodatime.version>
-        <johnzon.version>1.2.15</johnzon.version>
-        <tomee.version>8.0.9</tomee.version>
-        <xbean.version>4.19</xbean.version>
-        <deltaspike.version>1.9.5</deltaspike.version>
+        <johnzon.version>1.2.21</johnzon.version>
+        <tomee.version>8.0.16</tomee.version>
+        <xbean.version>4.24</xbean.version>
+        <deltaspike.version>1.9.6</deltaspike.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <batchee.scmPubUrl>https://svn.apache.org/repos/infra/websites/production/geronimo/content/batchee</batchee.scmPubUrl>
         <batchee.scmPubCheckoutDirectory>${basedir}/.site-content</batchee.scmPubCheckoutDirectory>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>batchee</artifactId>
     <groupId>org.apache.batchee</groupId>
-    <version>1.0.3</version>
+    <version>1.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>batchee-test</artifactId>

--- a/tools/cli/pom.xml
+++ b/tools/cli/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>batchee-tools</artifactId>
     <groupId>org.apache.batchee</groupId>
-    <version>1.0.3</version>
+    <version>1.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>batchee-cli</artifactId>

--- a/tools/doc-api/pom.xml
+++ b/tools/doc-api/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>batchee-tools</artifactId>
     <groupId>org.apache.batchee</groupId>
-    <version>1.0.3</version>
+    <version>1.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>batchee-doc-api</artifactId>

--- a/tools/ee6/pom.xml
+++ b/tools/ee6/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>batchee-tools</artifactId>
         <groupId>org.apache.batchee</groupId>
-        <version>1.0.3</version>
+        <version>1.0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>batchee-ee6</artifactId>

--- a/tools/maven-plugin/pom.xml
+++ b/tools/maven-plugin/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>batchee-tools</artifactId>
     <groupId>org.apache.batchee</groupId>
-    <version>1.0.3</version>
+    <version>1.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>batchee-maven-plugin</artifactId>

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>batchee</artifactId>
         <groupId>org.apache.batchee</groupId>
-        <version>1.0.3</version>
+        <version>1.0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>batchee-tools</artifactId>

--- a/tools/spring-boot-batchee-ui/pom.xml
+++ b/tools/spring-boot-batchee-ui/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <artifactId>batchee-tools</artifactId>
     <groupId>org.apache.batchee</groupId>
-    <version>1.0.3</version>
+    <version>1.0.4-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
- Updates to 1.0.4-SNAPSHOT
- Updates some dependency versions
- Adds a fix to be able to run in CDI 4 environments without getting hit by NoSuchMethodErrors